### PR TITLE
read bios md5 file from share_init

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -36,7 +36,7 @@ module.exports = {
     romsExcludedFolders: ['downloaded_images'],
     screenshotsPath: '/recalbox/share/screenshots',
     biosPath: '/recalbox/share/bios/',
-    biosFilePath: '/recalbox/share/bios/readme.txt',
+    biosFilePath: '/recalbox/share_init/bios/readme.txt',
     esSystemsCfgPath: '/recalbox/share_init/system/.emulationstation/es_systems.cfg',
     systemSettingsCommand: 'python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.pyc',
     savesPath: '/recalbox/share/saves',


### PR DESCRIPTION
Users can delete the `share/bios/readme.txt` file, and it can be not up to date. So rather focus on the file from she share_init which is the REAL one

solves #57 