### PR TITLE
Don't crash when image path is an array

### DIFF
--- a/src/routes/get.js
+++ b/src/routes/get.js
@@ -107,6 +107,9 @@ router.get('/', async (req, res, next) => {
                 if ('releasedate' === field) {
                   value = parseGameReleaseDate(value);
                 } else if ('image' === field) {
+                  if (Array.isArray(value)) {
+                    value = value[0];
+                  }
                   value = path.join('/', system, value);
                 }
 


### PR DESCRIPTION
Fixes #77 

There's some situation in which the image path value is an array instead of a string (I'm not sure, but I suspect it has to do with the filename containing parentheses), causing the code to crash and preventing the ROM list to load. 

This fix checks if the value is an array and takes the first element as the path.