### PR TITLE
Résolution du soucis de mesure de la mémoire disponible

### DIFF
--- a/src/routes/get.js
+++ b/src/routes/get.js
@@ -127,7 +127,7 @@ router.get('/', async (req, res, next) => {
         data = await getEsSystems();
         break;
       case 'temperature':
-        const currentTemp = execSync('cat /sys/class/thermal/thermal_zone0/temp').toString() / 1000;
+        const currentTemp = execSync('cat /sys/class/thermal/thermal_zone0/temp 2> /dev/null || echo 0').toString() / 1000;
         const maxTemp = 100;
         const currentPercent = Math.floor(currentTemp * 100 / maxTemp);
 


### PR DESCRIPTION
Bonjour,

Voici ma pull request concernant #79 

comme j'ai mis dans le texte de commit, on parcoure directement /proc/meminfo et on prends comme disponible:
* MemFree: vraiment pas utilisée
* Buffers: dans les fichiers mais syncable par le système pour récupération
* Cached: cache disque, pour ne pas refaire des lectures. Facilement dropable par le système
* SReclaimable: cache à l'intérieur du système. Par exemple un cache sur les répertoires/fichiers parcourus

Au passage j'ai mis un commit concernant le #76 car le lançant sur virtualbox (pc donc) je n'avais pas le fichier de température de dispo, et ça plantait la page monitoring. J'ai juste mis un contournement pour que ça n'explose pas (ça mets 0°) mais c'est pas un vrai fix, on a pas la température (pas sûr que ce soit facile de mémoire).

J'ai rebuildé/relancé sur ma VM et "chez moi ça marche".

S'il y a un soucis avec le style ou autre, hésites pas à me demander.