### PR TITLE
Fix: [page monitoring] la consommation de CPU était tout le temps à 100%

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "md5-file": "^3.1.1",
     "multer": "^1.3.0",
     "superagent": "^3.4.1",
-    "xml2js": "^0.4.17"
+    "xml2js": "^0.4.17",
+    "sleep": "^5.1.1"
   },
   "scripts": {
     "start": "concurrently \"npm run server\" \"npm run client\"",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "md5-file": "^3.1.1",
     "multer": "^1.3.0",
     "superagent": "^3.4.1",
-    "xml2js": "^0.4.17",
-    "sleep": "^5.1.1"
+    "xml2js": "^0.4.17"
   },
   "scripts": {
     "start": "concurrently \"npm run server\" \"npm run client\"",

--- a/src/lib/osutils.js
+++ b/src/lib/osutils.js
@@ -1,4 +1,5 @@
 var _os = require('os');
+var _sleep = require('sleep');
 
 exports.platform = function(){
   return process.platform;
@@ -182,7 +183,7 @@ exports.cpuUsage = function(callback){
 exports.listCPUs = function () {
   var list = getCPUsList();
 
-  wait(300);
+  _sleep.msleep(300); // wait 300ms
 
   var stats = getCPUsList();
 
@@ -199,14 +200,6 @@ exports.listCPUs = function () {
   return list;
 };
 
-function wait(ms) {
-  var start = new Date().getTime();
-  var end = start;
-
-  while(end < start + ms) {
-    end = new Date().getTime();
-  }
-}
 
 function getCPUsList() {
   var cpus = _os.cpus();

--- a/src/lib/osutils.js
+++ b/src/lib/osutils.js
@@ -1,5 +1,4 @@
 var _os = require('os');
-var _sleep = require('sleep');
 
 exports.platform = function(){
   return process.platform;
@@ -180,11 +179,19 @@ exports.cpuUsage = function(callback){
   getCPUUsage(callback, false);
 };
 
+var prev_cpu = null;
 exports.listCPUs = function () {
-  var list = getCPUsList();
-
-  _sleep.msleep(300); // wait 300ms
-
+  var list = prev_cpu;
+  // On the first turn, we fake the result
+  if(list === null){
+      list = getCPUsList();
+      for (var i=0; i< list.length; i++){
+             list[i].percent = 0;
+      }
+      prev_cpu = list;
+      return list;
+  }
+  // real results are after 1s of display
   var stats = getCPUsList();
 
   for (var i = 0; i < stats.length; i++) {


### PR DESCRIPTION
Fix: [page monitoring] la consommation de CPU était invalide, car un CPU était montré systématiquement à 100% alors que rien n'était lancé sur la box.

En fait ce n'était pas un mauvais calcul, mais bien une consommation, dû en fait au wait de 300ms que l'on fait entre les deux mesures de CPU. Le wait était une attente active, qui consomme réélement le CPU, donc on avait toujours un CPU de consommé, celui qui fait la mesure.

ATTENTION: J'ai changé par un appel à la librairie sleep. Pour son installation elle repose sur un build d'un .cc. Si ça passe sans soucis sous un linux standard, je ne sais pas si ça passe sous le linux de recalbox avec le build.